### PR TITLE
Redo forms in `react-hook-form`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,6 @@
         "prettier"
     ],
     "rules": {
-        "prettier/prettier": "error"
+        "prettier/prettier": "warn"
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@hookform/resolvers": "^2.9.10",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.8",
     "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest",
@@ -13,9 +14,9 @@
     "@types/node": "^16.11.64",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
-    "formik": "^2.2.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.41.0",
     "react-router-dom": "6",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -1,0 +1,31 @@
+import { TextField as MuiTextField, TextFieldProps } from "@mui/material";
+import {
+  useController,
+  UseControllerProps,
+  FieldValues,
+} from "react-hook-form";
+
+// A thin wrapper around the Material UI TextField component
+// that wires it up to react-hook-form using the `useController` hook.
+const TextField = <FormContents extends FieldValues>({
+  name,
+  control,
+  ...rest
+}: UseControllerProps<FormContents> & TextFieldProps) => {
+  const { field, fieldState } = useController({
+    name,
+    control,
+  });
+
+  return (
+    <MuiTextField
+      {...field}
+      inputRef={field.ref}
+      error={typeof fieldState.error !== "undefined"}
+      helperText={fieldState.error?.message}
+      {...rest}
+    />
+  );
+};
+
+export default TextField;

--- a/src/scenes/login/index.tsx
+++ b/src/scenes/login/index.tsx
@@ -6,57 +6,57 @@ import {
   InputAdornment,
   Link,
   Stack,
-  TextField,
   Typography,
   useTheme,
 } from "@mui/material";
-import { useFormik } from "formik";
+import { useForm } from "react-hook-form";
 import { FC, useContext } from "react";
 import { Link as ReactRouterLink, useNavigate } from "react-router-dom";
-import * as Yup from "yup";
 import { AuthContext } from "../../hooks/auth";
+import TextField from "../../components/forms/TextField";
 
-const loginSchema = Yup.object().shape({
-  username: Yup.string().required("Username is required"),
-  password: Yup.string().required("Password is required"),
-});
+type FormContents = {
+  username: string;
+  password: string;
+};
 
 const Login: FC = () => {
   const { setSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
-  const theme = useTheme();
-  const formik = useFormik({
-    initialValues: {
+  const { control, formState, handleSubmit } = useForm<FormContents>({
+    defaultValues: {
       username: "",
       password: "",
     },
-    validationSchema: loginSchema,
-    onSubmit: (values, { setSubmitting }) => {
+  });
+  const theme = useTheme();
+
+  const onSubmit = (formContents: FormContents) => {
+    return new Promise((resolve) => {
       setTimeout(() => {
         // TODO: Do real sign-in implementation. The basic idea will stay the same.
-        alert("Woohoo! Signed in!");
-        setSubmitting(false);
+        // Redirection to "/" is not working as expected, but I wont bother trying
+        // to fix it unless it breaks in a real implementation.
+        console.log(JSON.stringify(formContents, null, 2));
         setSignedIn(true);
+        resolve(true);
         navigate("/");
-      }, 500);
-    },
-  });
+      }, 1500);
+    });
+  };
 
   return (
-    <form onSubmit={formik.handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <Stack spacing={2} alignItems="center" sx={{ marginTop: "15vh" }}>
         <Typography variant="h4" sx={{ paddingBottom: "1rem" }}>
           Sign In
         </Typography>
         <TextField
-          id="username"
           name="username"
+          control={control}
+          id="username"
           label="Username"
           required
-          value={formik.values.username}
-          onChange={formik.handleChange}
-          error={formik.touched.username && Boolean(formik.errors.username)}
-          helperText={formik.touched.username && formik.errors.username}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -67,13 +67,11 @@ const Login: FC = () => {
         />
         <TextField
           name="password"
-          type="password"
+          control={control}
+          id="password"
           label="Password"
+          type="password"
           required
-          value={formik.values.password}
-          onChange={formik.handleChange}
-          error={formik.touched.password && Boolean(formik.errors.password)}
-          helperText={formik.touched.password && formik.errors.password}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -95,10 +93,10 @@ const Login: FC = () => {
           </Link>
           <Button
             variant="contained"
-            disabled={formik.isSubmitting}
-            onClick={formik.submitForm}
+            type="submit"
+            disabled={formState.isSubmitting}
           >
-            {formik.isSubmitting ? (
+            {formState.isSubmitting ? (
               <CircularProgress
                 size={24}
                 sx={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,6 +1237,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@hookform/resolvers@^2.9.10":
+  version "2.9.10"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.10.tgz#e7e88942ee34e97b7bc937b0be4694194c9cd420"
+  integrity sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
@@ -3712,11 +3717,6 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -4654,19 +4654,6 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-formik@^2.2.9:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
-  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
-  dependencies:
-    deepmerge "^2.1.1"
-    hoist-non-react-statics "^3.3.0"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    react-fast-compare "^2.0.1"
-    tiny-warning "^1.0.2"
-    tslib "^1.10.0"
-
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -4922,7 +4909,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7575,10 +7562,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-fast-compare@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+react-hook-form@^7.41.0:
+  version "7.41.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.0.tgz#cc0871f4784e7233ac8466300da557d622154414"
+  integrity sha512-u1cHOXujr+AsNBoeCtcCuRwPh87mXAgKtXqd3qTCBgNFYzVZLXjYgLcynORpAgqhe24r5scucR8+6gfWaXBtHQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -8622,11 +8609,6 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tiny-warning@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -8693,7 +8675,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Main thing this PR does is replace `formik` with `react-hook-form`. I also introduced a wrapper around MUI's `TextField` component to hide away as much of the RHF plumbing as I could. The resulting forms are much more DRY.

I could've done a similar refactor using `formik`, but I like `react-hook-form`s API better.

Closes #1 